### PR TITLE
Upgrade to Node v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,10 @@
 
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8-browsers
-
-  container_config_lambda_node8: &container_config_lambda_node8
-    working_directory: ~/project/build
-    docker:
-      - image: lambci/lambda:build-nodejs8.10
+      - image: circleci/node:12
 
   workspace_root: &workspace_root
     ~/project
@@ -60,7 +55,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - checkout
       - run:
@@ -93,7 +88,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -109,7 +104,7 @@ jobs:
           destination: test-results
 
   publish:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:


### PR DESCRIPTION
- Test on a Node image for v12 rather than v8 as part of the Customer Products universal upgrade to v12.
- Remove Lambda Node image because it is not used.