### PR TITLE
Remove Heroku app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,9 +1,0 @@
-{
-  "env": {},
-  "formation": {
-    "web": {
-    "quantity": 1,
-    "size": "Standard-1X"
-    }
-  }
-}


### PR DESCRIPTION
This file is only needed for Node.js applications which are deployed to Heroku, not for packages.