### PR TITLE
Fix conflicting workspaces in publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,6 @@ workflows:
             <<: *filters_version_tag
           requires:
             - test-v16.14
-            - test-v14.19
 
   renovate-nori-build-test:
     jobs:


### PR DESCRIPTION
In theory, we want to make sure that the CircleCI tests have passed before we publish the package to npm. Unfortunately, requiring a job as a dependency of another job implicitly tells the dependent job to use the dependency's workspace layer. If we want to wait on both Node 14 and Node 16 tests to pass before starting the `publish` job, we also need to attach to both of their workspace layers, causing a conflict seeing as they install different build artefacts. There doesn't seem to be any way to explicitly specify which workspace layers you want a job to attach to, so we instead have to not require the Node 14 tests to pass before the package is published. This is less than ideal but there doesn't seem to be any way around this.