### PR TITLE
Upgrade ecmaVersion 2018 -> 2020

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const config = {
 		'node': true
 	},
 	'parserOptions': {
-		'ecmaVersion': 2018,
+		'ecmaVersion': 2020,
 		'sourceType': 'module'
 	},
 	'rules': {


### PR DESCRIPTION
This PR upgrades the `index.js` `config.parserOptions.ecmaVersion` from `2018` to `2020` so that it does not throw a parsing error for usage of optional chaining.

### Example code
```js
const packageLockJsonStringifiedObject =
	systemNameToHeadBranchPackageFilesMap[camelCase(systemName)] &&
	systemNameToHeadBranchPackageFilesMap[camelCase(systemName)].packageLockJson?.text;
```

### Before
```
/Users/andy.gout/Documents/dotcom-biz-ops-package-updater/src/task.js
  175:81  error  Parsing error: Unexpected token .
```

### After
No error

I propose this be issued as a major release as there is the possibility that some rules have been made more stringent and will result in error for code that is currently passing the linting standards.