### PR TITLE
CPP-1971: remove n-gage references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,5 @@ typings/
 # next.js build output
 .next
 
-# Shared configuration managed by @financial-times/n-gage
-.editorconfig
+# dotcom-tool-kit temporary files
 /.toolkitstate

--- a/README.md
+++ b/README.md
@@ -15,7 +15,3 @@ module.exports = {
 Avoid using `.eslintrc` file format since [it has been depracated.](https://eslint.org/docs/user-guide/configuring#configuration-file-formats-1)
 
 You can find the docs for ESLint shareable configs [here](https://eslint.org/docs/developer-guide/shareable-configs).
-
-## Related
-
-This shared config is being used by [n-gage](https://github.com/Financial-Times/n-gage).


### PR DESCRIPTION
Remove references to n-gage as it is now decommissioned.