### PR TITLE
Delete .github/settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,2 +1,0 @@
-# See https://github.com/Financial-Times/github-apps-config-next for details
-_extends: github-apps-config-next


### PR DESCRIPTION
this controls the Probot Settings app, which we're phasing out in Customer Products